### PR TITLE
Fix Griffin-Lim loop in spectrogram inversion

### DIFF
--- a/audio_processing.py
+++ b/audio_processing.py
@@ -135,9 +135,8 @@ class TacotronSTFT(torch.nn.Module):
         
         # Griffin-Lim
         for _ in range(n_iter):
-            full = torch.polar(spectrogram, angles)
-            inverse = self.stft_fn.inverse(spectrogram, angles)
-            _, angles = self.stft_fn.transform(inverse)
+            waveform = self.stft_fn.inverse(spectrogram, angles)
+            _, angles = self.stft_fn.transform(waveform)
 
         waveform = self.stft_fn.inverse(spectrogram, angles)
         return waveform.squeeze(1)


### PR DESCRIPTION
## Summary
- remove unused variable in `mel_spectrogram_to_wave`
- iterate Griffin-Lim using waveform

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683fbbe4dc808333a0777a7f10436f32